### PR TITLE
Gives focus to the window if not topmost

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -202,7 +202,7 @@ namespace PoeTradeSearch
 
         private void Window_Activated(object sender, EventArgs e)
         {
-
+            Activate();
         }
 
         private void Window_Deactivated(object sender, EventArgs e)


### PR DESCRIPTION
If the always_on_top option is set to false, the application window now is getting focus properly and appears on top of other windows.